### PR TITLE
Fix #1: Persist continuous JS setting across restarts

### DIFF
--- a/chrome/content/ff-overlay.js
+++ b/chrome/content/ff-overlay.js
@@ -173,7 +173,16 @@ if ("undefined" == typeof (HeaderToolChrome) ) {
                                         this.preferencies.setBoolPref("onoff", false); 
                                 }
 
-                           
+                                // Restore continuous JS checkbox state
+                                try{
+                                        var cjsValue = headertoolModule.HeaderTool.getCountinuosJS();
+                                        var cjsCheckbox = document.getElementById("cjs");
+                                        if(cjsCheckbox){
+                                                cjsCheckbox.checked = cjsValue;
+                                        }
+                                }catch(exx){
+                                        this.LOG("Exception restoring cjs state: "+exx);
+                                }
                                 
                                 this.setCode( this.text );
                                 this.LOG("Loading Preferencies... [done]");

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -1,4 +1,5 @@
 
 pref("extensions.headertool.preferencies.onoff", false);
 pref("extensions.headertool.preferencies.editor","");
+pref("extensions.headertool.preferencies.cjs", false);
 

--- a/modules/headertoolModule.js
+++ b/modules/headertoolModule.js
@@ -51,6 +51,27 @@ headertoolModule.HeaderTool = {
         
         setCountinuosJS: function(b){
                 this.cjs=b;
+                // Persist the continuous JS setting
+                try {
+                        var preferencies = Components.classes["@mozilla.org/preferences-service;1"]
+                                .getService(Components.interfaces.nsIPrefService)
+                                .getBranch("extensions.headertool.preferencies.");
+                        preferencies.setBoolPref("cjs", b);
+                } catch(e) {
+                        this.LOG("Failed to save cjs preference: " + e);
+                }
+        },
+
+        getCountinuosJS: function(){
+                try {
+                        var preferencies = Components.classes["@mozilla.org/preferences-service;1"]
+                                .getService(Components.interfaces.nsIPrefService)
+                                .getBranch("extensions.headertool.preferencies.");
+                        this.cjs = preferencies.getBoolPref("cjs");
+                } catch(e) {
+                        this.cjs = false;
+                }
+                return this.cjs;
         },
         
         getWin: function(){


### PR DESCRIPTION
## Summary
Fixes #1 - The 'continuous JS' checkbox was not saved/restored across browser restarts or sidebar re-opens.

## Root Cause
- The `cjs` checkbox in `ff-sidebar.xul` was hardcoded to `checked="false"`
- `setCountinuosJS()` only set a runtime variable without persisting to preferences
- `loadPref()` never restored the checkbox state from preferences

## Changes
- **defaults/preferences/prefs.js**: Added `cjs` preference default
- **modules/headertoolModule.js**: `setCountinuosJS()` now saves to prefs; added `getCountinuosJS()` to read the saved value
- **chrome/content/ff-overlay.js**: `loadPref()` now restores checkbox state from preferences on load

## Testing
1. Open HeaderTool sidebar
2. Check 'continuous JS'
3. Close and reopen sidebar → checkbox should remain checked
4. Restart browser → checkbox should remain checked