### PR TITLE
Fix #2: Header Tool not started on browser start

### DIFF
--- a/chrome/content/ff-overlay.js
+++ b/chrome/content/ff-overlay.js
@@ -220,7 +220,11 @@ if ("undefined" == typeof (HeaderToolChrome) ) {
                                 }
 
                                 headertoolModule.HeaderTool.setText(text)
-                                this.togleOnOff();
+                                // Only toggle if not already on
+                                var value = this.preferencies.getBoolPref("onoff");
+                                if(!value){
+                                        this.togleOnOff();
+                                }
                         },
 
 
@@ -229,7 +233,11 @@ if ("undefined" == typeof (HeaderToolChrome) ) {
                          * ======================================= */
                         clear : function() {
                                 headertoolModule.HeaderTool.clear();
-                                this.togleOnOff();
+                                // Only toggle if currently on
+                                var value = this.preferencies.getBoolPref("onoff");
+                                if(value){
+                                        this.togleOnOff();
+                                }
                         },
 
 

--- a/chrome/content/ff-sidebar.xul
+++ b/chrome/content/ff-sidebar.xul
@@ -23,7 +23,7 @@
                   accesskey="C" 
                   id="headertool_button_clear" 
                   disabled="true"
-                  oncommand="HeaderToolChrome.BrowserOverlay.clear();HeaderToolChrome.BrowserOverlay.togleOnOff();this.setAttribute('disabled', 'true');document.getElementById('headertool_button_apply').setAttribute('disabled', 'false');"
+                  oncommand="HeaderToolChrome.BrowserOverlay.clear();this.setAttribute('disabled', 'true');document.getElementById('headertool_button_apply').setAttribute('disabled', 'false');"
                   crop="end" 
                   tooltiptext="Click here to restore the default headers" 
                   persist="disabled"        />


### PR DESCRIPTION
## Summary
Fixes #2 - HeaderTool ignores the ON/OFF preference at browser startup, requiring manual F4 → OFF → ON toggle.

## Root Cause
`togleOnOff()` blindly flips the boolean preference. When `loadPref()` found `onoff=true` at startup and called `parser()`, `parser()` would immediately toggle it back to `false`, effectively disabling the tool.

Additionally, the OFF button in the sidebar called both `clear()` and `togleOnOff()`, causing a double-toggle that could leave the state inconsistent.

## Changes
- **chrome/content/ff-overlay.js**: 
  - `parser()` now checks the current pref value and only toggles if not already on
  - `clear()` now checks and only toggles if currently on
- **chrome/content/ff-sidebar.xul**: Removed redundant `togleOnOff()` call from OFF button (already handled by `clear()`)

## Testing
1. Set headers and click ON
2. Restart browser
3. Headers should be active immediately without manual toggle