### PR TITLE
Fix #5: Clipboard not working on Ubuntu/Linux

### DIFF
--- a/chrome/content/ff-overlay.js
+++ b/chrome/content/ff-overlay.js
@@ -332,7 +332,7 @@ if ("undefined" == typeof (HeaderToolChrome) ) {
                         copyToClip:function(text){
                                 var gClipboardHelper = Components.classes["@mozilla.org/widget/clipboardhelper;1"].  
                                 getService(Components.interfaces.nsIClipboardHelper);  
-                                gClipboardHelper.copyString(text);  
+                                gClipboardHelper.copyString(text, document);  
                         },
 
                         serialize:function(trailing){


### PR DESCRIPTION
## Summary
Fixes #5 - wget/curl clipboard copy shows success alert but nothing is actually placed on the clipboard on Ubuntu.

## Root Cause
On Linux/X11, `nsIClipboardHelper.copyString(text)` requires a document reference as the second argument to properly interact with the X selection clipboard. Without it, the call appears to succeed but the data never reaches the system clipboard.

## Changes
- **chrome/content/ff-overlay.js**: Pass `document` as second arg to `gClipboardHelper.copyString()`

## Testing
1. On Ubuntu/Linux, open HeaderTool
2. Click wget or curl menu item
3. Paste in terminal → headers should now appear