### PR TITLE
Fix #9: Update URLs from Google Code to GitHub

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -8,8 +8,8 @@
     <em:creator>Lorenzo Pavesi</em:creator>
     <em:contributor></em:contributor>
     <em:description>A simple modify header extension</em:description>
-    <em:updateInfoURL>http://code.google.com/p/headertool/</em:updateInfoURL>
-    <em:homepageURL>http://code.google.com/p/headertool/</em:homepageURL>
+    <em:updateInfoURL>https://github.com/loreii/HeaderTool</em:updateInfoURL>
+    <em:homepageURL>https://github.com/loreii/HeaderTool</em:homepageURL>
     <em:iconURL>chrome://headertool/skin/Crocodile.png</em:iconURL>
     <em:targetApplication>
       <Description>

--- a/modules/headertoolModule.js
+++ b/modules/headertoolModule.js
@@ -147,7 +147,7 @@ headertoolModule.HeaderTool = {
 
                                 var jsStart;
                                 var jsEnd;
-                                var s = new Components.utils.Sandbox("http://code.google.com/p/headertool/");
+                                var s = new Components.utils.Sandbox("https://github.com/loreii/HeaderTool");
                                 //importing utility method inside the sandbox
                                 s.b64                    = headertoolModule.HeaderTool.b64;
                                 s.href                   = headertoolModule.HeaderTool.href;


### PR DESCRIPTION
## Summary
Fixes #9 - All references still pointed to the defunct Google Code repository.

## Changes
- **install.rdf**: Updated `homepageURL` and `updateInfoURL` to https://github.com/loreii/HeaderTool
- **modules/headertoolModule.js**: Updated Sandbox URL from Google Code to GitHub

## Note
The Firefox addon page at addons.mozilla.org would also need to be updated manually by the extension author through the AMO developer hub — that can't be done via code.