### PR TITLE
Fix #11: Prevent HeaderTool from breaking Firefox Sync

### DIFF
--- a/modules/headertoolModule.js
+++ b/modules/headertoolModule.js
@@ -68,6 +68,20 @@ headertoolModule.HeaderTool = {
                   var httpChannel = subject.QueryInterface(Components.interfaces.nsIHttpChannel);
                   var currURL = httpChannel.URI.spec
 
+                  // Skip internal Firefox requests (Sync, updates, telemetry, etc.)
+                  try{
+                          if(currURL.indexOf("services.mozilla.com") > -1 ||
+                             currURL.indexOf("sync.services.mozilla.com") > -1 ||
+                             currURL.indexOf("accounts.firefox.com") > -1 ||
+                             currURL.indexOf("aus5.mozilla.org") > -1 ||
+                             currURL.indexOf("telemetry.mozilla.org") > -1 ||
+                             currURL.indexOf("oauth.accounts.firefox.com") > -1 ||
+                             currURL.indexOf("token.services.mozilla.com") > -1){
+                            this.LOG("Skipping internal Firefox URL: "+currURL);
+                            return;
+                          }
+                  }catch(ex){}
+
                   try{
                           this.LOG("apply headers on URL : "+currURL);
                           this.LOG("cjs    : "+this.cjs);


### PR DESCRIPTION
## Summary
Fixes #11 - HeaderTool breaks Firefox Sync when enabled.

## Root Cause
The `http-on-modify-request` observer intercepts ALL HTTP requests, including internal Firefox Sync requests to Mozilla's servers. Custom headers would overwrite or interfere with Sync authentication tokens.

## Changes
- **modules/headertoolModule.js**: Added URL allowlist check at the top of the observer. Requests to Mozilla internal services (Sync, accounts, updates, telemetry) are now skipped entirely.

## Excluded domains
- `services.mozilla.com` / `sync.services.mozilla.com`
- `accounts.firefox.com` / `oauth.accounts.firefox.com`
- `token.services.mozilla.com`
- `aus5.mozilla.org` (updates)
- `telemetry.mozilla.org`

## Testing
1. Enable HeaderTool with custom headers
2. Firefox Sync should continue working normally
3. Custom headers should still apply to regular web requests